### PR TITLE
enables sqitch add

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM perl:latest
+RUN apt-get update \
+    && apt-get install -y vim \
+    && rm -fr /var/lib/apt/lists/*
 #RUN apk --update add perl make
 #RUN cpan inc::latest
 RUN cpan App::Sqitch


### PR DESCRIPTION
When I use `sqitch add` via image `docteurklein/sqitch:pgsql`, I got:

```Shell
$ docker run -v $(pwd):/src:rw -v /tmp:/tmp:rw -it --rm docteurklein/sqitch:pgsql add artifacts_job_id --requires artifacts --require appschema
"vi /tmp/CgjGYhQJEY" failed to start: "No such file or directory"
```

After adding `vim` in this image, it works.