### PR TITLE
Install mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ docker-sqitch
 # run
 
     docker run --rm docteurklein/sqitch:pgsql
+    docker run --volume $(pwd):/src --rm docteurklein/sqitch:mysql
 
 # build
 

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,2 +1,2 @@
 FROM docteurklein/sqitch:base
-RUN cpan DBD::mysql
+RUN cpan DBD::mysql && apt-get update && apt-get install -y --no-install-recommends mysql-client && apt-get clean


### PR DESCRIPTION
This fixes #6 

Before this change:

```
~/migrations/eliot$ docker run --volume $(pwd):/src --rm docteurklein/sqitch:mysql deploy -t eliot_test
Deploying changes to eliot_test                                                                                                                                      
  + tiny_table ............ not ok          
"mysql" failed to start: "No such file or directory"                                                                                                                 
                                         
Deploy failed
```

After this change (using `sqitch:mysql` as the tag for this docker container):
```
~/migrations/eliot$ docker run --volume $(pwd):/src --rm sqitch:mysql deploy -t eliot_test                                            
Deploying changes to eliot_test          
  + tiny_table .. ok
```

I also made a note in the readme about mounting the current directory into the docker container so that `sqitch` can access your migration files.